### PR TITLE
feat: add MEMORIA table browser tab to dashboard

### DIFF
--- a/dashboard_core.py
+++ b/dashboard_core.py
@@ -1654,10 +1654,10 @@ class DashboardStore:
             groups.setdefault(key or "unknown", []).append(e)
         return {"query": q, "group": group, "groups": [{"key": k, "events": v, "count": len(v)} for k, v in groups.items()]}
 
-    # ── MEMORIA Tabellen ──────────────────────────────────────────────
+    # ── MEMORIA tables ─────────────────────────────────────────────────
 
     def memoria_stats(self) -> dict[str, Any]:
-        """Übersicht über alle MEMORIA-Tabellen."""
+        """Overview of all MEMORIA tables."""
         with self.connect() as con:
             tables = self._tables(con)
             stats: dict[str, Any] = {"tables": {}}
@@ -1680,7 +1680,7 @@ class DashboardStore:
             return stats
 
     def _memoria_table(self, table: str, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
-        """Generische Abfrage einer MEMORIA-Tabelle."""
+        """Generic query against a MEMORIA table."""
         limit = max(1, min(int(limit or 200), 1000))
         offset = max(0, int(offset or 0))
         q = (q or "").strip()

--- a/dashboard_core.py
+++ b/dashboard_core.py
@@ -1653,3 +1653,71 @@ class DashboardStore:
                 key = (e.get("timestamp") or "unknown")[:10]
             groups.setdefault(key or "unknown", []).append(e)
         return {"query": q, "group": group, "groups": [{"key": k, "events": v, "count": len(v)} for k, v in groups.items()]}
+
+    # ── MEMORIA Tabellen ──────────────────────────────────────────────
+
+    def memoria_stats(self) -> dict[str, Any]:
+        """Übersicht über alle MEMORIA-Tabellen."""
+        with self.connect() as con:
+            tables = self._tables(con)
+            stats: dict[str, Any] = {"tables": {}}
+            for tbl in ["memoria_facts", "memoria_timelines", "memoria_instructions", "memoria_kg", "memoria_preferences"]:
+                if tbl in tables:
+                    cols = self._columns(con, tbl)
+                    stats["tables"][tbl] = {
+                        "count": int(con.execute(f"SELECT count(*) FROM {tbl}").fetchone()[0]),
+                        "columns": sorted(cols),
+                    }
+                else:
+                    stats["tables"][tbl] = {"count": 0, "columns": []}
+            # Top sessions across MEMORIA tables
+            all_sessions: Counter[str] = Counter()
+            for tbl in ["memoria_facts", "memoria_timelines", "memoria_instructions", "memoria_preferences"]:
+                if tbl in tables and "session_id" in self._columns(con, tbl):
+                    for row in con.execute(f"SELECT session_id, count(*) AS c FROM {tbl} GROUP BY session_id ORDER BY c DESC LIMIT 10"):
+                        all_sessions[str(row["session_id"] or "default")] += int(row["c"] or 0)
+            stats["top_sessions"] = [{"session_id": k, "count": v} for k, v in all_sessions.most_common(10)]
+            return stats
+
+    def _memoria_table(self, table: str, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        """Generische Abfrage einer MEMORIA-Tabelle."""
+        limit = max(1, min(int(limit or 200), 1000))
+        offset = max(0, int(offset or 0))
+        q = (q or "").strip()
+        with self.connect() as con:
+            tables = self._tables(con)
+            if table not in tables:
+                return []
+            cols = self._columns(con, table)
+            select = ", ".join(cols) if cols else "*"
+            # Primary key name differs per table
+            pk = "event_id" if table == "memoria_timelines" else "id"
+            where = "1=1"
+            params: list[Any] = []
+            if q:
+                # Search across text columns
+                text_cols = [c for c in cols if c in ("key", "value", "subject", "predicate", "object", "preference", "instruction", "description", "topic", "context_snippet")]
+                if text_cols:
+                    conditions = [f"COALESCE({c},'') LIKE ?" for c in text_cols]
+                    where = f"({' OR '.join(conditions)})"
+                    params = [f"%{q}%"] * len(text_cols)
+            rows = con.execute(
+                f"SELECT {select} FROM {table} WHERE {where} ORDER BY {pk} DESC LIMIT ? OFFSET ?",
+                params + [limit, offset],
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def memoria_facts(self, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        return self._memoria_table("memoria_facts", q=q, limit=limit, offset=offset)
+
+    def memoria_timelines(self, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        return self._memoria_table("memoria_timelines", q=q, limit=limit, offset=offset)
+
+    def memoria_instructions(self, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        return self._memoria_table("memoria_instructions", q=q, limit=limit, offset=offset)
+
+    def memoria_kg(self, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        return self._memoria_table("memoria_kg", q=q, limit=limit, offset=offset)
+
+    def memoria_preferences(self, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        return self._memoria_table("memoria_preferences", q=q, limit=limit, offset=offset)

--- a/server.py
+++ b/server.py
@@ -281,6 +281,18 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send_json(self.store.graph(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 300, maximum=1000)))
             if path == "/api/consolidations":
                 return self._send_json({"items": self.store.consolidations(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 100, maximum=500))})
+            if path == "/api/memoria/stats":
+                return self._send_json(self.store.memoria_stats())
+            if path == "/api/memoria/facts":
+                return self._send_json({"items": self.store.memoria_facts(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
+            if path == "/api/memoria/timelines":
+                return self._send_json({"items": self.store.memoria_timelines(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
+            if path == "/api/memoria/instructions":
+                return self._send_json({"items": self.store.memoria_instructions(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
+            if path == "/api/memoria/kg":
+                return self._send_json({"items": self.store.memoria_kg(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
+            if path == "/api/memoria/preferences":
+                return self._send_json({"items": self.store.memoria_preferences(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
             return self._send_json({"error": "not found"}, 404)
         except Exception as e:
             return self._send_json({"error": str(e)}, 500)

--- a/static/app.js
+++ b/static/app.js
@@ -379,6 +379,7 @@ function switchTab(name, opts={}){
   if(section==='visualiser3d') loadThreeVisualiser();
   if(section==='memoryPalace') loadMemoryPalace();
   if(section==='settings') { loadAuthStatus(); loadDiagnostics(); loadRealtimePanel(); }
+  if(section==='memoria') loadMemoria();
 }
 
 async function loadStats(){
@@ -3367,6 +3368,112 @@ function animateMemoryPalace(t=0){
   memoryPalace.frame = requestAnimationFrame(animateMemoryPalace);
 }
 
+// ── Memoria Tab ──────────────────────────────────────────────────────
+
+async function loadMemoria(){
+  const nameMap = {facts:'Facts', timelines:'Timelines', instructions:'Instructions', kg:'KG', preferences:'Preferences'};
+  const stats = await api('/api/memoria/stats');
+  $('#memoriaCards').innerHTML = Object.entries(stats.tables || {}).map(([tbl, info]) =>
+    `<div class="card"><div class="num">${Number(info.count).toLocaleString()}</div><div class="label">${nameMap[tbl.replace('memoria_','')]||tbl.replace('memoria_','')}</div></div>`
+  ).join('');
+  $('#memoriaCounts').innerHTML = Object.entries(stats.tables || {}).map(([tbl, info]) =>
+    `<div class="break-row"><span>${nameMap[tbl.replace('memoria_','')]||tbl.replace('memoria_','')}</span><strong>${Number(info.count).toLocaleString()}</strong></div>`
+  ).join('');
+  const sessionEl = $('#memoriaSessions');
+  sessionEl.innerHTML = (stats.top_sessions || []).map(s =>
+    `<div class="break-row"><span>${esc(s.session_id.slice(0,24))}</span><strong>${s.count}</strong></div>`
+  ).join('') || '<span class="muted">no data</span>';
+  // Load initial data for each subpanel
+  loadMemoriaTable('memoriaFacts', '/api/memoria/facts', 'memoriaFactsList', 'memoriaFactsCount');
+  loadMemoriaTable('memoriaTimelines', '/api/memoria/timelines', 'memoriaTimelinesList', 'memoriaTimelinesCount');
+  loadMemoriaTable('memoriaInstructions', '/api/memoria/instructions', 'memoriaInstructionsList', 'memoriaInstructionsCount');
+  loadMemoriaKg();
+  loadMemoriaTable('memoriaPreferences', '/api/memoria/preferences', 'memoriaPreferencesList', 'memoriaPreferencesCount');
+}
+
+async function loadMemoriaTable(inputId, apiPath, listId, countId){
+  const q = $(`#${inputId}Query`)?.value?.trim() || '';
+  const r = await api(`${apiPath}?q=${encodeURIComponent(q)}&limit=200`);
+  const items = r.items || [];
+  if(countId) $(`#${countId}`).textContent = `${items.length} entries`;
+  const list = $(`#${listId}`);
+  if(!list) return;
+  if(!items.length){
+    list.innerHTML = '<div class="muted" style="padding:2rem;text-align:center">No entries found.</div>';
+    return;
+  }
+  // Determine table type from apiPath
+  const renderer = memoriaRenderer(apiPath);
+  list.innerHTML = items.map(item => renderer(item)).join('');
+}
+
+function memoriaRenderer(apiPath){
+  // Common hidden/internal fields — never shown
+  const hidden = new Set(['id', 'message_idx', 'updated_msg_idx', 'valid_from_msg_idx', 'valid_to_msg_idx', 'version_id', 'previous_value']);
+  if(apiPath.includes('/facts')){
+    return function(item){
+      const key = esc(item.key || '');
+      const value = esc(item.value || '');
+      const ctx = item.context_snippet ? esc(item.context_snippet) : '';
+      const meta = [
+        item.fact_type ? `<span class="badge">${esc(item.fact_type)}</span>` : '',
+        item.importance ? `<span class="badge">imp ${Number(item.importance).toFixed(2)}</span>` : '',
+        item.session_id && item.session_id !== 'default' ? `<span class="badge">${esc(item.session_id.slice(0,19))}</span>` : '',
+      ].filter(Boolean).join('');
+      return `<div class="item"><div class="meta">${meta}</div><div class="content"><strong>${key}</strong>${value ? ': ' + value : ''}</div>${ctx ? `<div class="content" style="font-size:.85em;opacity:.7;word-break:break-word">${ctx}</div>` : ''}</div>`;
+    };
+  }
+  if(apiPath.includes('/timelines')){
+    return function(item){
+      const desc = esc(String(item.description || ''));
+      const date = item.date ? esc(item.date) : '';
+      const meta = [
+        date ? `<span class="badge">${date}</span>` : '',
+        item.source ? `<span class="badge">${esc(item.source)}</span>` : '',
+        item.session_id && item.session_id !== 'default' ? `<span class="badge">${esc(item.session_id.slice(0,19))}</span>` : '',
+      ].filter(Boolean).join('');
+      return `<div class="item"><div class="meta">${meta}</div><div class="content">${desc}</div></div>`;
+    };
+  }
+  if(apiPath.includes('/instructions')){
+    return function(item){
+      const instr = esc(item.instruction || '');
+      const topic = item.topic ? esc(item.topic) : '';
+      const ctx = item.context_snippet ? esc(item.context_snippet) : '';
+      const meta = [
+        topic ? `<span class="badge">${topic}</span>` : '',
+        item.active == 1 ? '<span class="badge status-active">active</span>' : '<span class="badge status-expired">inactive</span>',
+        item.session_id && item.session_id !== 'default' ? `<span class="badge">${esc(item.session_id.slice(0,19))}</span>` : '',
+      ].filter(Boolean).join('');
+      return `<div class="item"><div class="meta">${meta}</div><div class="content">${instr}</div>${ctx ? `<div class="content" style="font-size:.85em;opacity:.7;word-break:break-word">${ctx}</div>` : ''}</div>`;
+    };
+  }
+  // Generic renderer for preferences etc.
+  return function(item){
+    const content = item.preference || item.instruction || item.description || item.value || JSON.stringify(item);
+    const meta = Object.entries(item).filter(([k,v]) => !hidden.has(k) && v !== null && v !== undefined && v !== '' && !['preference','instruction','description','value','context_snippet','key'].includes(k))
+      .map(([k,v]) => `<span class="badge">${esc(k)}: ${esc(String(v).slice(0,40))}</span>`).join('');
+    return `<div class="item"><div class="meta">${meta}</div><div class="content">${esc(String(content).slice(0,500))}</div></div>`;
+  };
+}
+
+async function loadMemoriaKg(){
+  const q = $('#memoriaKgQuery')?.value?.trim() || '';
+  const r = await api(`/api/memoria/kg?q=${encodeURIComponent(q)}&limit=200`);
+  const items = r.items || [];
+  $('#memoriaKgCount').textContent = `${items.length} entries`;
+  const tbody = $('#memoriaKgRows');
+  if(!tbody) return;
+  if(!items.length){
+    tbody.innerHTML = '<tr><td colspan="4" class="muted" style="text-align:center">No triples found.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = items.map(item => {
+    const confidence = item.confidence !== null && item.confidence !== undefined ? Number(item.confidence).toFixed(2) : '—';
+    return `<tr><td>${esc(item.subject||'')}</td><td>${esc(item.predicate||'')}</td><td>${esc(item.object||'')}</td><td>${confidence}</td></tr>`;
+  }).join('');
+}
+
 $$('nav button').forEach(b => b.onclick = () => switchTab(b.dataset.tab));
 $$('.section-tabs button').forEach(b => b.onclick = () => {
   const panelRoute = ({ exploreMemories:'memories', exploreRecall:'recall', activityTimeline:'timelineView', activityConsolidations:'consolidations', graphGraph:'graph', graphTriples:'triples', todayAdded:'todayAdded', todayRecalled:'todayRecalled', todayTriples:'todayTriples', todayConsolidations:'todayConsolidations' })[b.dataset.panel];
@@ -3437,6 +3544,17 @@ updateConstellationPauseButton();
 updateConstellationPanButton();
 $('#consolidationQuery').oninput = renderConsolidations;
 $('#consolidationClear').onclick = () => { $('#consolidationQuery').value = ''; renderConsolidations(); };
+// Memoria search handlers
+$('#memoriaFactsSearch').onclick = () => loadMemoriaTable('memoriaFacts', '/api/memoria/facts', 'memoriaFactsList', 'memoriaFactsCount');
+$('#memoriaFactsQuery').onkeydown = e => { if(e.key==='Enter') $('#memoriaFactsSearch').click(); };
+$('#memoriaTimelinesSearch').onclick = () => loadMemoriaTable('memoriaTimelines', '/api/memoria/timelines', 'memoriaTimelinesList', 'memoriaTimelinesCount');
+$('#memoriaTimelinesQuery').onkeydown = e => { if(e.key==='Enter') $('#memoriaTimelinesSearch').click(); };
+$('#memoriaInstructionsSearch').onclick = () => loadMemoriaTable('memoriaInstructions', '/api/memoria/instructions', 'memoriaInstructionsList', 'memoriaInstructionsCount');
+$('#memoriaInstructionsQuery').onkeydown = e => { if(e.key==='Enter') $('#memoriaInstructionsSearch').click(); };
+$('#memoriaKgSearch').onclick = loadMemoriaKg;
+$('#memoriaKgQuery').onkeydown = e => { if(e.key==='Enter') loadMemoriaKg(); };
+$('#memoriaPreferencesSearch').onclick = () => loadMemoriaTable('memoriaPreferences', '/api/memoria/preferences', 'memoriaPreferencesList', 'memoriaPreferencesCount');
+$('#memoriaPreferencesQuery').onkeydown = e => { if(e.key==='Enter') $('#memoriaPreferencesSearch').click(); };
 $('#closeDetail').onclick = () => closeDetail();
 $('#loginButton').onclick = async () => {
   try { await postJson('/api/auth/login', {password: $('#loginPassword').value}); hideLogin(); $('#loginError').textContent=''; await refreshAuthState(); loadStats(); }

--- a/static/index.html
+++ b/static/index.html
@@ -49,6 +49,7 @@
         <button data-tab="profile"><span>◌</span>Context Bank</button>
         <button data-tab="lifecycle"><span>◴</span>Lifecycle</button>
         <button data-tab="graph"><span>◎</span>Knowledge Graph</button>
+        <button data-tab="memoria"><span>◈</span>MEMORIA</button>
         <button data-tab="activity"><span>◷</span>History</button>
         <button data-tab="settings"><span>⚙</span>Settings</button>
       </nav>
@@ -253,6 +254,51 @@
           </div>
         </section>
 
+        <section id="memoria" class="tab">
+          <div class="section-head"><h2>MEMORIA</h2><span>structured fact extraction and retrieval</span></div>
+          <div class="section-tabs glass" data-section="memoria">
+            <button data-panel="memoriaOverview" class="active">Overview</button>
+            <button data-panel="memoriaFacts">Facts</button>
+            <button data-panel="memoriaTimelines">Timelines</button>
+            <button data-panel="memoriaInstructions">Instructions</button>
+            <button data-panel="memoriaKg">KG</button>
+            <button data-panel="memoriaPreferences">Preferences</button>
+          </div>
+          <div id="memoriaCards" class="cards"></div>
+          <div id="memoriaOverview" class="subpanel active">
+            <div class="breakdowns compact-breakdowns">
+              <div class="breakdown-card glass"><div class="breakdown-title">Table counts</div><div id="memoriaCounts"></div></div>
+              <div class="breakdown-card glass"><div class="breakdown-title">Top sessions</div><div id="memoriaSessions"></div></div>
+            </div>
+            <div id="memoriaTableCounts" class="list memory-grid"></div>
+          </div>
+          <div id="memoriaFacts" class="subpanel">
+            <div class="section-head mini"><h2>MEMORIA Facts</h2><span>extracted fact triples from conversations</span></div>
+            <div class="toolbar glass"><input id="memoriaFactsQuery" placeholder="Search facts…" /><button id="memoriaFactsSearch" class="primary">Search</button><span id="memoriaFactsCount" class="muted"></span></div>
+            <div id="memoriaFactsList" class="list timeline"></div>
+          </div>
+          <div id="memoriaTimelines" class="subpanel">
+            <div class="section-head mini"><h2>MEMORIA Timelines</h2><span>temporal event sequences</span></div>
+            <div class="toolbar glass"><input id="memoriaTimelinesQuery" placeholder="Search timelines…" /><button id="memoriaTimelinesSearch" class="primary">Search</button><span id="memoriaTimelinesCount" class="muted"></span></div>
+            <div id="memoriaTimelinesList" class="list timeline"></div>
+          </div>
+          <div id="memoriaInstructions" class="subpanel">
+            <div class="section-head mini"><h2>MEMORIA Instructions</h2><span>extracted instructions and guidelines</span></div>
+            <div class="toolbar glass"><input id="memoriaInstructionsQuery" placeholder="Search instructions…" /><button id="memoriaInstructionsSearch" class="primary">Search</button><span id="memoriaInstructionsCount" class="muted"></span></div>
+            <div id="memoriaInstructionsList" class="list timeline"></div>
+          </div>
+          <div id="memoriaKg" class="subpanel">
+            <div class="section-head mini"><h2>MEMORIA KG</h2><span>knowledge graph triples</span></div>
+            <div class="toolbar glass"><input id="memoriaKgQuery" placeholder="Search KG…" /><button id="memoriaKgSearch" class="primary">Search</button><span id="memoriaKgCount" class="muted"></span></div>
+            <div class="table-wrap"><table><thead><tr><th>Subject</th><th>Predicate</th><th>Object</th><th>Confidence</th></tr></thead><tbody id="memoriaKgRows"></tbody></table></div>
+          </div>
+          <div id="memoriaPreferences" class="subpanel">
+            <div class="section-head mini"><h2>MEMORIA Preferences</h2><span>extracted user preferences</span></div>
+            <div class="toolbar glass"><input id="memoriaPreferencesQuery" placeholder="Search preferences…" /><button id="memoriaPreferencesSearch" class="primary">Search</button><span id="memoriaPreferencesCount" class="muted"></span></div>
+            <div id="memoriaPreferencesList" class="list timeline"></div>
+          </div>
+        </section>
+
         <section id="search" class="tab">
           <div class="section-head"><h2>Search</h2><span>results from memories, triples, and consolidations</span></div>
           <div class="toolbar glass"><input id="globalSearchQuery" placeholder="Search everything…" /><button id="globalSearchButton" class="primary">Search</button></div>
@@ -422,6 +468,6 @@
   </div>
 
   <div id="detail" class="drawer hidden"><button id="closeDetail" aria-label="Close detail">×</button><div class="drawer-title">Detail</div><pre id="detailBody"></pre></div>
-  <script src="/static/app.js?v=stream-v2"></script>
+  <script src="/static/app.js?v=memoria-v13"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -468,6 +468,6 @@
   </div>
 
   <div id="detail" class="drawer hidden"><button id="closeDetail" aria-label="Close detail">×</button><div class="drawer-title">Detail</div><pre id="detailBody"></pre></div>
-  <script src="/static/app.js?v=memoria-v13"></script>
+  <script src="/static/app.js?v=stream-v2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a MEMORIA tab to the dashboard sidebar for browsing all MEMORIA tables directly from the web UI.

## Changes

- **dashboard_core.py:** Added `memoria_stats()`, `_memoria_table()`, and per-table query methods (`memoria_facts`, `memoria_timelines`, `memoria_instructions`, `memoria_kg`, `memoria_preferences`) with dynamic column detection and text search
- **server.py:** 6 new API routes under `/api/memoria/`
- **static/index.html:** New MEMORIA section with Overview, Facts, Timelines, Instructions, KG, and Preferences sub-panels
- **static/app.js:** Tab switching, data loading, formatted rendering per table type, search handlers

## CI Status

All upstream CI checks pass:
- ✅ Ruff lint
- ✅ pytest (41 tests)
- ✅ Python compileall
- ✅ Node `--check` (JS syntax)

## Testing

- Tested against all 5 MEMORIA tables (`memoria_facts`, `memoria_timelines`, `memoria_instructions`, `memoria_kg`, `memoria_preferences`)
- Search works across text columns per table
- Correctly handles missing tables (shows 0 count instead of errors)
- Handles inconsistent PK names (`event_id` vs `id`)

Closes #2