### PR TITLE
polish: refine dashboard visual design

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -58,7 +58,7 @@ function prettyTime(value){
   return new Intl.DateTimeFormat(undefined, {day:'numeric', month:'short', year:'numeric', hour:'numeric', minute:'2-digit'}).format(d);
 }
 function meta(item, opts={}){
-  const status = item.status || 'active';
+  const status = String(item.status || 'active').toLowerCase();
   const scope = String(item.scope || '').trim();
   const session = String(item.session_id || '').trim();
   const rawTime = item.timestamp || item.created_at || '';
@@ -66,13 +66,18 @@ function meta(item, opts={}){
   const kind = item.memory_kind || item.tier || item.source || 'memory';
   const veracity = String(item.veracity || 'unknown').toLowerCase();
   const lifecycle = item.degradation_label ? `${item.degradation_label}${item.degradation_tier ? ` · T${item.degradation_tier}` : ''}` : '';
-  const scopeBadge = scope && scope !== 'session' ? `<span class="badge" title="scope: ${esc(scope)}">${esc(scope)}</span>` : '';
-  const sessionBadge = opts.sessionLink !== false && session && session !== 'default' ? `<button type="button" class="badge session-link" data-session="${esc(session)}" title="Open session: ${esc(session)}">session ${esc(shortId(session))}</button>` : '';
-  const timeBadge = timeLabel ? `<span class="meta-time" title="${esc(rawTime)}">${esc(timeLabel)}</span>` : '';
-  const veracityBadge = `<span class="badge trust-${esc(veracity)}" title="veracity: ${esc(veracity)} · recall weight ${Number(item.trust_weight ?? 0).toFixed(2)}">${esc(veracity)}</span>`;
-  const lifecycleBadge = lifecycle ? `<span class="badge lifecycle-${esc(item.degradation_label)}" title="degradation tier: ${esc(item.degradation_tier)} · recall weight ${Number(item.degradation_weight ?? 1).toFixed(2)}">${esc(lifecycle)}</span>` : '';
-  return `<div class="meta"><span class="badge">${esc(kind)}</span><span class="badge status-${esc(status)}">${esc(status)}</span>${veracityBadge}${lifecycleBadge}<span class="badge">importance ${Number(item.importance ?? 0).toFixed(2)}</span>${scopeBadge}${sessionBadge}${timeBadge}</div>`;
+  const importance = Number(item.importance ?? 0);
+  const pills = [`<span class="badge kind-badge" title="memory type: ${esc(kind)}">${esc(kind)}</span>`];
+  if(status && status !== 'active') pills.push(`<span class="badge status-${esc(status)}" title="status: ${esc(status)}">${esc(status)}</span>`);
+  if(veracity && veracity !== 'unknown') pills.push(`<span class="badge trust-${esc(veracity)}" title="veracity: ${esc(veracity)} · recall weight ${Number(item.trust_weight ?? 0).toFixed(2)}">${esc(veracity)}</span>`);
+  if(lifecycle) pills.push(`<span class="badge lifecycle-${esc(item.degradation_label)}" title="degradation tier: ${esc(item.degradation_tier)} · recall weight ${Number(item.degradation_weight ?? 1).toFixed(2)}">${esc(lifecycle)}</span>`);
+  if(importance > 0) pills.push(`<span class="badge importance-badge" title="importance: ${importance.toFixed(2)}">${importance.toFixed(2)}</span>`);
+  if(scope && scope !== 'session') pills.push(`<span class="badge" title="scope: ${esc(scope)}">${esc(scope)}</span>`);
+  if(opts.sessionLink !== false && session && session !== 'default') pills.push(`<button type="button" class="badge session-link" data-session="${esc(session)}" title="Open session: ${esc(session)}">${esc(shortId(session))}</button>`);
+  if(timeLabel) pills.push(`<span class="meta-time" title="${esc(rawTime)}">${esc(timeLabel)}</span>`);
+  return `<div class="meta">${pills.join('')}</div>`;
 }
+function cleanContent(content){ return String(content || '').replace(/^\[(USER|ASSISTANT|SYSTEM)\]\s*/i, ''); }
 function roleOf(content){ const m = String(content || '').match(/^\[(USER|ASSISTANT|SYSTEM)\]/i); return m ? m[1].toLowerCase() : ''; }
 function liveEventMeta(item){
   const eventType = String(item.live_event_type || item.event_type || '').toUpperCase();
@@ -85,7 +90,7 @@ function liveEventMeta(item){
   };
   return map[eventType] || ['', ''];
 }
-function memoryItem(item, opts={}){ const role = roleOf(item.content); const roleBadge = role ? `<span class="role role-${role}">${role}</span>` : ''; const selectedSet = opts.selectedSet || bulkSelection; const checkClass = opts.checkClass || 'memory-check'; const selectable = opts.selectable ? `<label class="memory-select" title="Select memory"><input type="checkbox" class="${esc(checkClass)}" data-id="${esc(item.id)}" ${selectedSet.has(item.id) ? 'checked' : ''} /></label>` : ''; const [liveClass, liveLabel, liveBadgeClass] = liveEventMeta(item); const liveBadge = liveLabel ? `<span class="badge live-badge ${esc(liveBadgeClass)}">${esc(liveLabel)}</span>` : ''; return `<div class="item memory-card ${role ? 'has-role' : ''} ${opts.selectable ? 'selectable' : ''} ${liveClass ? `live-${esc(liveClass)}` : ''}" data-id="${esc(item.id)}">${selectable}${meta(item)}${liveBadge}${roleBadge}<div class="content">${esc(item.content)}</div></div>`; }
+function memoryItem(item, opts={}){ const role = roleOf(item.content); const roleBadge = role ? `<span class="role role-${role}">${role}</span>` : ''; const selectedSet = opts.selectedSet || bulkSelection; const checkClass = opts.checkClass || 'memory-check'; const selectable = opts.selectable ? `<label class="memory-select" title="Select memory"><input type="checkbox" class="${esc(checkClass)}" data-id="${esc(item.id)}" ${selectedSet.has(item.id) ? 'checked' : ''} /></label>` : ''; const [liveClass, liveLabel, liveBadgeClass] = liveEventMeta(item); const liveBadge = liveLabel ? `<span class="badge live-badge ${esc(liveBadgeClass)}">${esc(liveLabel)}</span>` : ''; const displayContent = cleanContent(item.content); return `<div class="item memory-card ${role ? 'has-role' : ''} ${opts.selectable ? 'selectable' : ''} ${liveClass ? `live-${esc(liveClass)}` : ''}" data-id="${esc(item.id)}">${selectable}<div class="item-topline">${roleBadge}${liveBadge}</div>${meta(item)}<div class="content">${esc(displayContent)}</div></div>`; }
 function canonicalTab(tab){
   if(tab === 'constellation') return 'visualiserlegacy';
   if(tab === 'visualiser3d') return 'visualiser';

--- a/static/index.html
+++ b/static/index.html
@@ -18,7 +18,7 @@
           <div class="brand-mark">M</div>
           <div>
             <div class="brand-name">Mnemosyne</div>
-            <div class="brand-sub">Memory For Hermes</div>
+            <div class="brand-sub">Hermes Memory</div>
           </div>
         </button>
         <div class="mobile-topbar-actions">
@@ -31,7 +31,7 @@
         <div class="brand-mark">M</div>
         <div>
           <div class="brand-name">Mnemosyne</div>
-          <div class="brand-sub">Memory For Hermes</div>
+          <div class="brand-sub">Hermes Memory</div>
         </div>
       </button>
       <div class="menu-search glass-mini">
@@ -39,19 +39,19 @@
         <button id="menuSearchButton" class="primary" aria-label="Search memory">⌕</button>
       </div>
       <nav>
-        <button data-tab="overview" class="active"><span>⌘</span>Overview</button>
-        <button data-tab="today"><span>✦</span>Today</button>
-        <button data-tab="visualiser"><span>✹</span>Visualiser</button>
+        <button data-tab="overview" class="active"><span>OV</span>Overview</button>
+        <button data-tab="today"><span>TD</span>Today</button>
+        <button data-tab="visualiser"><span>3D</span>Visualiser</button>
         <button data-tab="palace" class="nav-hidden" aria-hidden="true" tabindex="-1"><span>♜</span>Mnemosyne Labyrinth</button>
         <button data-tab="visualiserlegacy" class="nav-hidden" aria-hidden="true" tabindex="-1"><span>✺</span>Visualiser Legacy</button>
-        <button data-tab="review"><span>⚑</span>Review</button>
-        <button data-tab="memories"><span>▦</span>Memories</button>
-        <button data-tab="profile"><span>◌</span>Context Bank</button>
-        <button data-tab="lifecycle"><span>◴</span>Lifecycle</button>
-        <button data-tab="graph"><span>◎</span>Knowledge Graph</button>
-        <button data-tab="memoria"><span>◈</span>MEMORIA</button>
-        <button data-tab="activity"><span>◷</span>History</button>
-        <button data-tab="settings"><span>⚙</span>Settings</button>
+        <button data-tab="review"><span>RV</span>Review</button>
+        <button data-tab="memories"><span>MM</span>Memories</button>
+        <button data-tab="profile"><span>CB</span>Context Bank</button>
+        <button data-tab="lifecycle"><span>LC</span>Lifecycle</button>
+        <button data-tab="graph"><span>KG</span>Knowledge Graph</button>
+        <button data-tab="memoria"><span>MR</span>MEMORIA</button>
+        <button data-tab="activity"><span>HS</span>History</button>
+        <button data-tab="settings"><span>ST</span>Settings</button>
       </nav>
       <div class="theme-switch glass-mini">
         <span>Theme</span>
@@ -63,9 +63,9 @@
     <div class="workspace">
       <header class="hero">
         <div>
-          <div class="eyebrow">Local memory visualiser</div>
-          <h1>Your agent’s memory, finally visible.</h1>
-          <p>Browse working memories, episodic summaries, triples, and consolidation history from one private dashboard.</p>
+          <div class="eyebrow">Hermes memory console</div>
+          <h1>Private memory, cleanly mapped.</h1>
+          <p>Search, review, and trace working memories, summaries, triples, and consolidation history from one local dashboard.</p>
         </div>
         <div class="status-card">
           <div class="status-label">Database</div>
@@ -449,7 +449,7 @@
             </div>
             <div class="glass settings-card">
               <div class="breakdown-title">Mnemosyne 3.x sync diagnostics</div>
-              <p class="muted">Read-only Mnemosyne streaming and DeltaSync readiness for the installed package. Useful for future multi-machine sync, not daily memory browsing.</p>
+              <p class="muted">Sync diagnostics: read-only Mnemosyne streaming and DeltaSync readiness. Useful for debugging future multi-machine sync, not daily memory browsing.</p>
               <div id="settingsDeltaSync" class="realtime-deltasync"></div>
             </div>
           </div>
@@ -463,7 +463,7 @@
 
   <div id="loginOverlay" class="login-overlay hidden">
     <div class="login-card glass">
-      <div class="brand compact-brand"><div class="brand-mark">M</div><div><div class="brand-name">Mnemosyne</div><div class="brand-sub">Memory For Hermes</div></div></div>
+      <div class="brand compact-brand"><div class="brand-mark">M</div><div><div class="brand-name">Mnemosyne</div><div class="brand-sub">Hermes Memory</div></div></div>
       <h2>Password required</h2>
       <p class="muted">This dashboard has optional password auth enabled.</p>
       <input id="loginPassword" type="password" placeholder="Password" />

--- a/static/style.css
+++ b/static/style.css
@@ -422,3 +422,125 @@ button:disabled{opacity:.45;cursor:not-allowed;transform:none!important}
   #patternInsights .section-head.mini h2{white-space:nowrap;overflow-wrap:normal;word-break:normal}
   #patternInsights .section-head.mini span{text-align:left;white-space:normal;letter-spacing:.12em}
 }
+
+
+/* Premium UI revamp v1: quieter, product-grade surface language. */
+:root{
+  --bg:#07080a;
+  --panel:#0c0d10;
+  --panel2:#111318;
+  --panel3:#171a21;
+  --text:#f4f5f7;
+  --soft:#c5cad4;
+  --muted:#858c9a;
+  --faint:#596070;
+  --line:rgba(255,255,255,.072);
+  --line2:rgba(255,255,255,.13);
+  --border:var(--line);
+  --accent:#7b7cff;
+  --accent2:#9aa3ff;
+  --green:#47d18c;
+  --amber:#e6b35f;
+  --red:#ff6f7d;
+  --shadow:0 18px 48px rgba(0,0,0,.34);
+  --font-brand-serif:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  --font-brand-script:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  --font-brand-alt:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+  --sidebar-bg:linear-gradient(180deg,rgba(12,13,16,.96),rgba(7,8,10,.92));
+  --hero-bg:linear-gradient(180deg,rgba(255,255,255,.035),rgba(255,255,255,.012));
+  --card-bg:linear-gradient(180deg,rgba(255,255,255,.045),rgba(255,255,255,.018));
+  --item-bg:linear-gradient(180deg,rgba(255,255,255,.038),rgba(255,255,255,.016));
+  --glass-bg:rgba(255,255,255,.026);
+  --input-bg:rgba(255,255,255,.035);
+  --table-bg:rgba(12,13,16,.82);
+  --graph-bg:linear-gradient(180deg,rgba(12,13,16,.95),rgba(9,10,13,.93));
+}
+[data-theme="light"]{
+  --bg:#f6f6f3;
+  --panel:#ffffff;
+  --panel2:#f0f0ed;
+  --panel3:#e8e8e4;
+  --text:#191a1d;
+  --soft:#35383f;
+  --muted:#6d727c;
+  --faint:#9aa0a9;
+  --line:rgba(20,22,27,.10);
+  --line2:rgba(20,22,27,.18);
+  --border:var(--line);
+  --accent:#4f46e5;
+  --accent2:#2563eb;
+  --green:#178a55;
+  --amber:#9a6415;
+  --red:#c2414b;
+  --shadow:0 18px 44px rgba(20,22,27,.10);
+  --sidebar-bg:linear-gradient(180deg,rgba(255,255,255,.94),rgba(246,246,243,.90));
+  --hero-bg:linear-gradient(180deg,rgba(255,255,255,.82),rgba(255,255,255,.50));
+  --card-bg:linear-gradient(180deg,rgba(255,255,255,.98),rgba(246,246,243,.80));
+  --item-bg:linear-gradient(180deg,rgba(255,255,255,.99),rgba(246,246,243,.72));
+  --glass-bg:rgba(255,255,255,.68);
+  --input-bg:rgba(255,255,255,.84);
+  --table-bg:rgba(255,255,255,.88);
+  --graph-bg:linear-gradient(180deg,rgba(255,255,255,.92),rgba(246,246,243,.90));
+}
+html{background:var(--bg)}
+body{font-size:14px;line-height:1.5;letter-spacing:-.012em;font-feature-settings:"cv01","ss03","kern";text-rendering:geometricPrecision;background:
+  radial-gradient(circle at 72% -12%,rgba(123,124,255,.10),transparent 31rem),
+  linear-gradient(180deg,var(--bg),#050609 70%);}
+[data-theme="light"] body{background:linear-gradient(180deg,#fbfbf9,var(--bg) 54%)}
+.shell{grid-template-columns:264px minmax(0,1fr)}
+.sidebar{padding:18px 14px;border-right-color:var(--line);box-shadow:inset -1px 0 0 rgba(255,255,255,.018);backdrop-filter:blur(18px)}
+.brand{gap:12px;margin-bottom:18px;padding:8px 8px 10px;border-radius:14px}
+.brand-mark{display:grid!important;place-items:center!important;width:36px!important;height:36px!important;flex:0 0 36px!important;border-radius:11px!important;background:linear-gradient(180deg,rgba(255,255,255,.10),rgba(255,255,255,.035))!important;border:1px solid var(--line2)!important;color:var(--text)!important;font:650 15px/1 Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif!important;text-shadow:none!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.08),0 8px 24px rgba(0,0,0,.18)!important}
+.brand-name{font-size:18px!important;font-weight:650!important;letter-spacing:-.035em!important;line-height:1.08!important}
+.brand-sub{margin-top:2px!important;font-size:10px!important;letter-spacing:.12em!important;text-transform:uppercase!important;color:var(--muted)!important;font-weight:650!important}
+.menu-search{border-radius:12px;padding:7px;background:rgba(255,255,255,.027);border-color:var(--line);margin:10px 0 14px}.menu-search input{font-size:13px;color:var(--text)}.menu-search button{min-height:34px;border-radius:9px}
+nav{display:grid;gap:3px}
+nav button{height:38px;justify-content:flex-start;gap:9px;border-radius:10px!important;border:1px solid transparent!important;background:transparent!important;color:var(--muted)!important;font-weight:560!important;letter-spacing:-.01em!important;box-shadow:none!important;transition:background .14s ease,border-color .14s ease,color .14s ease,transform .14s ease}
+nav button span{display:grid;place-items:center;width:25px;height:22px;border-radius:7px;background:rgba(255,255,255,.035);border:1px solid transparent;color:var(--faint);font-size:9px!important;font-weight:760;letter-spacing:.04em;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;line-height:1;flex:0 0 25px}
+nav button:hover{transform:none!important;background:rgba(255,255,255,.035)!important;color:var(--soft)!important;border-color:var(--line)!important}
+nav button.active{background:rgba(255,255,255,.060)!important;color:var(--text)!important;border-color:rgba(255,255,255,.105)!important}
+nav button.active span{background:rgba(123,124,255,.16);border-color:rgba(154,163,255,.24);color:var(--accent2)}
+.theme-switch{border:1px solid var(--line);border-radius:12px;background:rgba(255,255,255,.026);padding:8px 9px}.theme-toggle{border-radius:9px;padding:6px 9px;background:rgba(255,255,255,.032)}
+.workspace{min-width:0}.hero{margin:0;padding:48px clamp(28px,5vw,72px) 32px;display:grid;grid-template-columns:minmax(0,1fr) minmax(250px,360px);gap:28px;align-items:end;border-bottom:1px solid var(--line);background:var(--hero-bg)}
+.eyebrow{margin-bottom:13px;color:var(--accent2);font-size:11px;font-weight:720;letter-spacing:.14em;text-transform:uppercase}.hero h1{max-width:780px;margin:0;color:var(--text);font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif!important;font-size:clamp(38px,5vw,64px);font-weight:620;letter-spacing:-.065em;line-height:.97}.hero p{max-width:620px;margin:18px 0 0;color:var(--muted);font-size:15.5px;line-height:1.65;letter-spacing:-.01em}.status-card{border:1px solid var(--line);border-radius:16px;background:rgba(255,255,255,.026);box-shadow:none;padding:16px}.status-label{color:var(--faint);font-size:10px;letter-spacing:.13em;font-weight:760}.db-path{margin-top:6px;color:var(--soft);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.45;word-break:break-all}
+main{padding:28px clamp(24px,4vw,56px) 56px}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(170px,1fr));gap:12px;margin-bottom:18px}.card{min-height:106px;border:1px solid var(--line);border-radius:16px;background:var(--card-bg);box-shadow:none;padding:17px 18px}.card:before,.item:before{display:none!important}.card .num{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif!important;font-size:34px;font-weight:650;letter-spacing:-.055em;color:var(--text);background:none!important;-webkit-background-clip:initial!important}.card .label{margin-top:6px;color:var(--muted);font-size:10.5px;font-weight:720;letter-spacing:.12em;text-transform:uppercase}.breakdowns{gap:12px;margin-bottom:18px}.breakdown-card,.glass,.profile-section,.settings-card,.timeline-group,.pattern-panel{border-color:var(--line)!important;background:rgba(255,255,255,.026)!important;box-shadow:none!important;border-radius:16px!important}.breakdown-card{padding:15px}.breakdown-title{color:var(--muted);font-size:10px;letter-spacing:.13em;font-weight:780}.breakdown-row{padding:7px 0;border-bottom:1px solid rgba(255,255,255,.045)}
+.section-head{margin:26px 0 13px}.section-head h2,.result-section h3,.graph-inspector h3,.action-modal-card h2,.search-summary h3{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif!important;font-weight:620!important;letter-spacing:-.045em!important;color:var(--text)!important}.section-head h2{font-size:24px;line-height:1.08}.section-head span{color:var(--faint);font-size:10.5px;letter-spacing:.13em;font-weight:760;text-transform:uppercase}.quick-actions,.section-tabs,.toolbar,.bulk-bar{border-radius:14px!important;background:rgba(255,255,255,.026)!important;border-color:var(--line)!important;box-shadow:none!important;padding:8px!important}.quick-actions button,.section-tabs button,.toolbar button,button,.drawer-action{border-radius:10px!important;border:1px solid var(--line)!important;background:rgba(255,255,255,.036)!important;color:var(--soft)!important;font-weight:650!important;box-shadow:inset 0 1px 0 rgba(255,255,255,.05)!important}.primary,.section-tabs button.active,.quick-actions button:hover,.toolbar button:hover,button:hover{border-color:rgba(154,163,255,.30)!important;background:rgba(123,124,255,.13)!important;color:var(--text)!important;transform:none!important}input,select,textarea{border:1px solid var(--line)!important;border-radius:10px!important;background:var(--input-bg)!important;color:var(--text)!important;box-shadow:none!important}input:focus,select:focus,textarea:focus{outline:none!important;border-color:rgba(154,163,255,.38)!important;box-shadow:0 0 0 3px rgba(123,124,255,.10)!important}
+.memory-grid{grid-template-columns:repeat(auto-fill,minmax(340px,1fr));gap:12px}.item{min-height:130px;border:1px solid var(--line);border-radius:16px;padding:15px;background:var(--item-bg);box-shadow:none;transition:border-color .14s ease,background .14s ease,transform .14s ease}.item:hover{transform:translateY(-1px);box-shadow:none;border-color:rgba(154,163,255,.24);background:linear-gradient(180deg,rgba(255,255,255,.048),rgba(255,255,255,.022))}.item-topline{min-height:23px;display:flex;align-items:center;gap:6px;margin-bottom:7px}.item-topline:empty{display:none}.meta{display:flex;gap:5px;flex-wrap:wrap;margin:0 0 10px;color:var(--muted);font-size:11px}.badge,.session-chip,.context-type-chip,.context-meta span{border-radius:7px!important;border:1px solid var(--line)!important;background:rgba(255,255,255,.030)!important;color:var(--muted)!important;padding:3px 7px!important;font-size:11px!important;font-weight:620!important;letter-spacing:0!important;text-transform:none!important;line-height:1.25!important}.kind-badge{color:var(--soft)!important}.importance-badge{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--accent2)!important;background:rgba(123,124,255,.08)!important;border-color:rgba(154,163,255,.18)!important}button.badge.session-link{color:var(--accent2)!important;background:rgba(123,124,255,.08)!important;border-color:rgba(154,163,255,.22)!important}.meta-time{margin-left:auto;color:var(--faint);font-size:11px;line-height:1.8;white-space:nowrap}.role{margin:0;border-radius:7px!important;padding:3px 7px;font-size:10px;font-weight:720;letter-spacing:.06em;background:rgba(255,255,255,.035)!important;color:var(--soft)!important;border-color:var(--line)!important}.role-user{color:#b9ecff!important}.role-assistant{color:#c9c8ff!important}.role-system{color:#f2d18f!important}.content{color:var(--soft);font-size:13.5px;line-height:1.55;-webkit-line-clamp:4}.live-badge{margin:0!important}.live-badge-new,.status-active{color:var(--green)!important;border-color:rgba(71,209,140,.24)!important;background:rgba(71,209,140,.07)!important}.status-expired,.live-badge-consolidated{color:var(--amber)!important;border-color:rgba(230,179,95,.25)!important;background:rgba(230,179,95,.07)!important}.status-superseded,.live-badge-invalidated{color:var(--red)!important;border-color:rgba(255,111,125,.25)!important;background:rgba(255,111,125,.07)!important}
+.table-wrap,.graph-wrap,.three-viewport,.constellation-wrap{border-radius:18px!important;border-color:var(--line)!important;box-shadow:none!important}table{background:var(--table-bg)}th{background:rgba(255,255,255,.034)!important;color:var(--muted)!important;font-size:10.5px;letter-spacing:.11em;text-transform:uppercase}td{border-bottom-color:var(--line)!important;color:var(--soft)!important}.drawer,.action-modal-card,.login-card{border-radius:20px!important;border-color:var(--line2)!important;background:rgba(12,13,16,.97)!important;box-shadow:0 28px 90px rgba(0,0,0,.48)!important}.drawer pre,.detail-content{background:rgba(255,255,255,.025)!important;border-color:var(--line)!important}
+[data-theme="light"] .sidebar{box-shadow:inset -1px 0 0 rgba(20,22,27,.04)}[data-theme="light"] body{color:var(--text)}[data-theme="light"] .brand-mark{background:linear-gradient(180deg,#fff,#f0f0ed)!important;color:#1d2026!important;border-color:rgba(20,22,27,.12)!important;box-shadow:0 8px 18px rgba(20,22,27,.06)!important}[data-theme="light"] nav button span{background:rgba(20,22,27,.035)}[data-theme="light"] nav button.active span{background:rgba(79,70,229,.10);border-color:rgba(79,70,229,.18);color:var(--accent)}[data-theme="light"] .card,[data-theme="light"] .item{box-shadow:0 1px 0 rgba(20,22,27,.03)}[data-theme="light"] .breakdown-row{border-bottom-color:rgba(20,22,27,.07)}[data-theme="light"] .drawer,[data-theme="light"] .action-modal-card,[data-theme="light"] .login-card{background:rgba(255,255,255,.98)!important;box-shadow:0 28px 80px rgba(20,22,27,.16)!important}
+@media(max-width:980px){.hero{grid-template-columns:1fr;align-items:start}.status-card{max-width:100%}.shell{grid-template-columns:244px minmax(0,1fr)}}
+@media(max-width:760px),(max-width:940px) and (max-height:520px){
+  .sidebar{padding:0 12px}.mobile-topbar{height:62px}.compact-brand .brand-mark{width:34px!important;height:34px!important;flex-basis:34px!important;font-size:14px!important}.compact-brand .brand-name{font-size:18px!important}.compact-brand .brand-sub{font-size:9px!important}.mobile-menu-toggle,.topbar-theme-toggle{border-radius:11px!important;background:rgba(255,255,255,.034)!important}.sidebar-menu{padding-bottom:12px}nav{gap:5px}nav button{height:38px!important;font-size:13px!important}.hero{display:none}main{padding:14px 14px 30px}.cards{grid-template-columns:repeat(2,minmax(0,1fr));gap:9px}.card{min-height:92px;border-radius:14px!important;padding:14px}.card .num{font-size:30px}.memory-grid{grid-template-columns:1fr;gap:10px}.item{border-radius:14px;padding:13px}.meta-time{margin-left:0;width:100%}.section-head h2{font-size:23px}.section-tabs,.quick-actions,.toolbar,.bulk-bar{border-radius:13px!important}.quick-actions button{min-height:36px}}
+@media(max-width:420px){.cards{grid-template-columns:1fr}.memory-grid{grid-template-columns:1fr}.card .label{white-space:normal}.section-head{align-items:flex-start;flex-direction:column;gap:4px}.section-head span{text-align:left!important}}
+
+
+/* Premium UI revamp v1.1: light-theme contrast/readability pass. */
+[data-theme="light"]{
+  --soft:#25282f;
+  --muted:#515865;
+  --faint:#707887;
+  --line:rgba(19,22,29,.14);
+  --line2:rgba(19,22,29,.24);
+  --border:var(--line);
+}
+[data-theme="light"] .content{color:#25282f;font-weight:450}
+[data-theme="light"] .badge,
+[data-theme="light"] .session-chip,
+[data-theme="light"] .context-type-chip,
+[data-theme="light"] .context-meta span{color:#3d4350!important;background:rgba(19,22,29,.045)!important;border-color:rgba(19,22,29,.15)!important}
+[data-theme="light"] .kind-badge{color:#20242b!important}
+[data-theme="light"] .importance-badge,
+[data-theme="light"] button.badge.session-link{color:#3730a3!important;background:rgba(79,70,229,.09)!important;border-color:rgba(79,70,229,.20)!important}
+[data-theme="light"] .role{background:rgba(19,22,29,.055)!important;color:#343944!important;border-color:rgba(19,22,29,.16)!important}
+[data-theme="light"] .role-user{color:#075985!important;background:rgba(14,165,233,.10)!important;border-color:rgba(14,116,144,.20)!important}
+[data-theme="light"] .role-assistant{color:#4338ca!important;background:rgba(79,70,229,.10)!important;border-color:rgba(79,70,229,.20)!important}
+[data-theme="light"] .role-system{color:#8a5b09!important;background:rgba(217,119,6,.10)!important;border-color:rgba(180,83,9,.20)!important}
+[data-theme="light"] .meta-time{color:#596170}
+[data-theme="light"] nav button{color:#535b68!important}
+[data-theme="light"] nav button:hover,[data-theme="light"] nav button.active{color:#171a20!important;background:rgba(19,22,29,.045)!important;border-color:rgba(19,22,29,.12)!important}
+[data-theme="light"] .section-head span,[data-theme="light"] .breakdown-title,[data-theme="light"] .card .label{color:#5e6675}
+[data-theme="light"] .quick-actions button,[data-theme="light"] .section-tabs button,[data-theme="light"] .toolbar button,[data-theme="light"] button,[data-theme="light"] .drawer-action{color:#303640!important;background:rgba(19,22,29,.040)!important;border-color:rgba(19,22,29,.14)!important}
+[data-theme="light"] button:disabled{opacity:.52!important}
+[data-theme="light"] input,[data-theme="light"] select,[data-theme="light"] textarea{color:#171a20!important;background:#fff!important;border-color:rgba(19,22,29,.18)!important}
+[data-theme="light"] .memory-select{background:#fff!important;border-color:rgba(19,22,29,.20)!important}
+@media(min-width:761px){.content{font-size:14px}.meta{font-size:11.5px}nav button{font-size:13.5px}}


### PR DESCRIPTION
## Summary
- Restyles the dashboard toward a quieter, more product-grade dark/light theme with stronger hierarchy and reduced glow/glass effects.
- Simplifies sidebar labels, hero copy, cards, buttons, and metadata badges without changing API calls or backend behavior.
- Cleans memory-card display by moving role/live badges into a topline and hiding noisy default metadata such as active/unknown/zero-importance badges.

## Validation
- `node --check static/app.js`
- `python -m pytest -q tests -o 'addopts='`
