### PR TITLE
feat: add Persona & Canonical Facts dashboard tab

### DIFF
--- a/dashboard_core.py
+++ b/dashboard_core.py
@@ -1740,3 +1740,95 @@ class DashboardStore:
 
     def memoria_preferences(self, q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
         return self._memoria_table("memoria_preferences", q=q, limit=limit, offset=offset)
+
+    def persona_facts(self, tier: str = "", topic: str = "", q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        """Query L3 persona facts from memoria_persona."""
+        limit = max(1, min(int(limit or 200), 1000))
+        offset = max(0, int(offset or 0))
+        q = (q or "").strip()
+        tier = (tier or "").strip()
+        topic = (topic or "").strip()
+        with self.connect() as con:
+            tables = self._tables(con)
+            if "memoria_persona" not in tables:
+                return []
+            where = ["1=1"]
+            params: list[Any] = []
+            if tier:
+                where.append("tier = ?")
+                params.append(tier)
+            if topic:
+                where.append("topic = ?")
+                params.append(topic)
+            if q:
+                where.append("(COALESCE(content,'') LIKE ? OR COALESCE(topic,'') LIKE ?)")
+                params.extend([f"%{q}%", f"%{q}%"])
+            rows = con.execute(
+                f"SELECT id, session_id, tier, topic, content, confidence, source_memory_id, "
+                f"created_at, last_reinforced_at, reinforcement_count, promotion_reason "
+                f"FROM memoria_persona WHERE {' AND '.join(where)} "
+                f"ORDER BY CASE tier WHEN 'permanent' THEN 1 WHEN 'long_term' THEN 2 WHEN 'working' THEN 3 ELSE 4 END, "
+                f"reinforcement_count DESC, id DESC LIMIT ? OFFSET ?",
+                params + [limit, offset],
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def persona_stats(self) -> dict[str, Any]:
+        """Aggregate counts per persona tier and topic."""
+        with self.connect() as con:
+            tables = self._tables(con)
+            if "memoria_persona" not in tables:
+                return {"total": 0, "by_tier": [], "by_topic": []}
+            total = con.execute("SELECT COUNT(*) FROM memoria_persona").fetchone()[0]
+            by_tier = [dict(r) for r in con.execute(
+                "SELECT tier, COUNT(*) AS count FROM memoria_persona GROUP BY tier ORDER BY count DESC"
+            )]
+            by_topic = [dict(r) for r in con.execute(
+                "SELECT topic, COUNT(*) AS count FROM memoria_persona GROUP BY topic ORDER BY count DESC LIMIT 20"
+            )]
+            return {"total": total, "by_tier": by_tier, "by_topic": by_topic}
+
+    def canonical_facts(self, owner_id: str = "", category: str = "", q: str = "", limit: int = 200, offset: int = 0) -> list[dict[str, Any]]:
+        """Query owner-scoped canonical facts."""
+        limit = max(1, min(int(limit or 200), 1000))
+        offset = max(0, int(offset or 0))
+        q = (q or "").strip()
+        owner_id = (owner_id or "").strip()
+        category = (category or "").strip()
+        with self.connect() as con:
+            tables = self._tables(con)
+            if "canonical_facts" not in tables:
+                return []
+            where = ["valid_until IS NULL"]
+            params: list[Any] = []
+            if owner_id:
+                where.append("owner_id = ?")
+                params.append(owner_id)
+            if category:
+                where.append("category = ?")
+                params.append(category)
+            if q:
+                where.append("(COALESCE(owner_id,'') LIKE ? OR COALESCE(category,'') LIKE ? OR COALESCE(name,'') LIKE ? OR COALESCE(body,'') LIKE ?)")
+                params.extend([f"%{q}%", f"%{q}%", f"%{q}%", f"%{q}%"])
+            rows = con.execute(
+                f"SELECT id, owner_id, category, name, body, source, confidence, version, valid_from, created_at "
+                f"FROM canonical_facts WHERE {' AND '.join(where)} "
+                f"ORDER BY owner_id, category, name LIMIT ? OFFSET ?",
+                params + [limit, offset],
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def canonical_stats(self) -> dict[str, Any]:
+        """Aggregate canonical fact counts per owner and category."""
+        with self.connect() as con:
+            tables = self._tables(con)
+            if "canonical_facts" not in tables:
+                return {"total": 0, "by_owner": [], "by_category": []}
+            total = con.execute("SELECT COUNT(*) FROM canonical_facts WHERE valid_until IS NULL").fetchone()[0]
+            by_owner = [dict(r) for r in con.execute(
+                "SELECT owner_id, COUNT(*) AS count FROM canonical_facts WHERE valid_until IS NULL GROUP BY owner_id ORDER BY count DESC"
+            )]
+            by_category = [dict(r) for r in con.execute(
+                "SELECT category, COUNT(*) AS count FROM canonical_facts WHERE valid_until IS NULL GROUP BY category ORDER BY count DESC LIMIT 20"
+            )]
+            return {"total": total, "by_owner": by_owner, "by_category": by_category}

--- a/server.py
+++ b/server.py
@@ -398,6 +398,24 @@ class Handler(BaseHTTPRequestHandler):
                 return self._send_json({"items": self.store.memoria_kg(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
             if path == "/api/memoria/preferences":
                 return self._send_json({"items": self.store.memoria_preferences(q=q.get("q", ""), limit=_safe_int(q.get("limit"), 200, maximum=1000), offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000))})
+            if path == "/api/persona":
+                return self._send_json({
+                    "items": self.store.persona_facts(
+                        tier=q.get("tier", ""), topic=q.get("topic", ""), q=q.get("q", ""),
+                        limit=_safe_int(q.get("limit"), 200, maximum=1000),
+                        offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000),
+                    ),
+                    "stats": self.store.persona_stats(),
+                })
+            if path == "/api/canonical":
+                return self._send_json({
+                    "items": self.store.canonical_facts(
+                        owner_id=q.get("owner_id", ""), category=q.get("category", ""), q=q.get("q", ""),
+                        limit=_safe_int(q.get("limit"), 200, maximum=1000),
+                        offset=_safe_int(q.get("offset"), 0, minimum=0, maximum=100000),
+                    ),
+                    "stats": self.store.canonical_stats(),
+                })
             return self._send_json({"error": "not found"}, 404)
         except (BrokenPipeError, ConnectionResetError):
             return

--- a/static/app.js
+++ b/static/app.js
@@ -376,20 +376,27 @@ function closeMobileMenuForViewportChange(){
   if(activeElement && activeElement.closest('.menu-search')) return;
   closeMobileMenu();
 }
+function canonicalTab(tab){
+  if(tab === 'constellation') return 'visualiserlegacy';
+  if(tab === 'visualiser3d') return 'visualiser';
+  if(tab === 'history') return 'activity';
+  if(tab === 'personafacts') return 'personafacts';
+  return tab || 'overview';
+}
+function sectionFor(name){
+  return ({ visualiser:'visualiser3d', palace:'memoryPalace', visualiserlegacy:'constellation', constellation:'constellation', recall:'explore', memories:'explore', history:'activity', timelineView:'activity', consolidations:'activity', triples:'graph', todayAdded:'today', todayRecalled:'today', todayTriples:'today', todayConsolidations:'today', persona:'personafacts', personafacts:'personafacts', canonical:'personafacts', canonicalfacts:'personafacts' })[name] || name;
+}
+function defaultPanelFor(section){
+  return ({ explore:'exploreMemories', activity:'activityTimeline', graph:'graphGraph', today:'todayAdded', personafacts:'personaPanel' })[section];
+}
+function panelFor(name){
+  return ({ memories:'exploreMemories', recall:'exploreRecall', history:'activityTimeline', timelineView:'activityTimeline', consolidations:'activityConsolidations', graph:'graphGraph', triples:'graphTriples', today:'todayAdded', todayAdded:'todayAdded', todayRecalled:'todayRecalled', todayTriples:'todayTriples', todayConsolidations:'todayConsolidations', persona:'personaPanel', personafacts:'personaPanel', canonical:'canonicalPanel', canonicalfacts:'canonicalPanel' })[name] || defaultPanelFor(name);
+}
 function showPanel(sectionId, panelId){
   const section = $(`#${sectionId}`);
   if(!section || !panelId) return;
   section.querySelectorAll('.subpanel').forEach(panel => panel.classList.toggle('active', panel.id === panelId));
   section.querySelectorAll('.section-tabs button').forEach(button => button.classList.toggle('active', button.dataset.panel === panelId));
-}
-function sectionFor(name){
-  return ({ visualiser:'visualiser3d', palace:'memoryPalace', visualiserlegacy:'constellation', constellation:'constellation', recall:'explore', memories:'explore', history:'activity', timelineView:'activity', consolidations:'activity', triples:'graph', todayAdded:'today', todayRecalled:'today', todayTriples:'today', todayConsolidations:'today' })[name] || name;
-}
-function defaultPanelFor(section){
-  return ({ explore:'exploreMemories', activity:'activityTimeline', graph:'graphGraph', today:'todayAdded' })[section];
-}
-function panelFor(name){
-  return ({ memories:'exploreMemories', recall:'exploreRecall', history:'activityTimeline', timelineView:'activityTimeline', consolidations:'activityConsolidations', graph:'graphGraph', triples:'graphTriples', today:'todayAdded', todayAdded:'todayAdded', todayRecalled:'todayRecalled', todayTriples:'todayTriples', todayConsolidations:'todayConsolidations' })[name] || defaultPanelFor(name);
 }
 function stopCanvasVisualiserLoop(){
   if(constellationScene.frame) cancelAnimationFrame(constellationScene.frame);
@@ -464,6 +471,56 @@ function switchTab(name, opts={}){
   if(section==='memoryPalace') loadMemoryPalace();
   if(section==='settings') { loadAuthStatus(); loadDiagnostics(); loadRuntimeDiagnostics(); loadRealtimePanel(); }
   if(section==='memoria') loadMemoria();
+  if(section==='personafacts') loadPersonaFacts();
+}
+
+async function loadPersonaFacts(){
+  await Promise.all([loadPersonaPanel(), loadCanonicalPanel()]);
+}
+async function loadPersonaPanel(){
+  const tier = $('#personaTierFilter')?.value || '';
+  const q = $('#personaQuery')?.value?.trim() || '';
+  const r = await api(`/api/persona?tier=${encodeURIComponent(tier)}&q=${encodeURIComponent(q)}&limit=200`);
+  const items = r.items || [];
+  const stats = r.stats || {};
+  const statBadges = [
+    `<span class="badge">total ${Number(stats.total || 0).toLocaleString()}</span>`,
+    ...(stats.by_tier || []).map(t => `<span class="badge tier-${esc(String(t.tier || 'unknown'))}">${esc(t.tier)} ${Number(t.count).toLocaleString()}</span>`),
+  ];
+  $('#personaStats').innerHTML = statBadges.join('');
+  const tbody = $('#personaRows');
+  if(!items.length){
+    tbody.innerHTML = '<tr><td colspan="5" class="muted" style="text-align:center">No persona facts found.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = items.map(item => {
+    const reinforced = item.last_reinforced_at ? prettyTime(item.last_reinforced_at) : '—';
+    const count = Number(item.reinforcement_count || 0);
+    return `<tr><td><span class="badge tier-${esc(item.tier || 'unknown')}">${esc(item.tier || '—')}</span></td><td>${esc(item.topic || '—')}</td><td>${esc(item.content || '')}</td><td title="${esc(item.last_reinforced_at || '')}">${esc(reinforced)}</td><td>${count.toLocaleString()}</td></tr>`;
+  }).join('');
+}
+async function loadCanonicalPanel(){
+  const owner = $('#canonicalOwnerFilter')?.value?.trim() || '';
+  const category = $('#canonicalCategoryFilter')?.value?.trim() || '';
+  const q = $('#canonicalQuery')?.value?.trim() || '';
+  const r = await api(`/api/canonical?owner_id=${encodeURIComponent(owner)}&category=${encodeURIComponent(category)}&q=${encodeURIComponent(q)}&limit=200`);
+  const items = r.items || [];
+  const stats = r.stats || {};
+  const statBadges = [
+    `<span class="badge">total ${Number(stats.total || 0).toLocaleString()}</span>`,
+    ...(stats.by_category || []).map(c => `<span class="badge">${esc(c.category)} ${Number(c.count).toLocaleString()}</span>`),
+  ];
+  $('#canonicalStats').innerHTML = statBadges.join('');
+  const tbody = $('#canonicalRows');
+  if(!items.length){
+    tbody.innerHTML = '<tr><td colspan="5" class="muted" style="text-align:center">No canonical facts found.</td></tr>';
+    return;
+  }
+  tbody.innerHTML = items.map(item => {
+    const body = String(item.body || '').replace(/\n/g, ' ');
+    const version = Number(item.version || 0);
+    return `<tr><td>${esc(item.owner_id || '—')}</td><td>${esc(item.category || '—')}</td><td>${esc(item.name || '—')}</td><td>${esc(body)}</td><td>${version.toLocaleString()}</td></tr>`;
+  }).join('');
 }
 
 async function loadStats(){
@@ -3594,7 +3651,7 @@ async function loadMemoriaKg(){
 
 $$('nav button').forEach(b => b.onclick = () => switchTab(b.dataset.tab));
 $$('.section-tabs button').forEach(b => b.onclick = () => {
-  const panelRoute = ({ exploreMemories:'memories', exploreRecall:'recall', activityTimeline:'timelineView', activityConsolidations:'consolidations', graphGraph:'graph', graphTriples:'triples', todayAdded:'todayAdded', todayRecalled:'todayRecalled', todayTriples:'todayTriples', todayConsolidations:'todayConsolidations' })[b.dataset.panel];
+  const panelRoute = ({ exploreMemories:'memories', exploreRecall:'recall', activityTimeline:'timelineView', activityConsolidations:'consolidations', graphGraph:'graph', graphTriples:'triples', todayAdded:'todayAdded', todayRecalled:'todayRecalled', todayTriples:'todayTriples', todayConsolidations:'todayConsolidations', personaPanel:'personafacts', canonicalPanel:'canonicalfacts' })[b.dataset.panel];
   if(panelRoute) { switchTab(panelRoute); return; }
   const section = b.closest('.tab')?.id;
   showPanel(section, b.dataset.panel);
@@ -3629,6 +3686,13 @@ $('#reviewExpiry').onclick = setSelectedReviewExpiry;
 $('#reviewExpire').onclick = expireSelectedReviewMemories;
 $('#globalSearchButton').onclick = loadGlobalSearch; $('#globalSearchQuery').onkeydown = e => { if(e.key==='Enter') loadGlobalSearch(); };
 $('#menuSearchButton').onclick = menuSearch; $('#menuSearchQuery').onkeydown = e => { if(e.key==='Enter') menuSearch(); };
+$('#personaSearch').onclick = loadPersonaPanel;
+$('#personaQuery').onkeydown = e => { if(e.key === 'Enter') loadPersonaPanel(); };
+$('#personaTierFilter').onchange = loadPersonaPanel;
+$('#canonicalSearch').onclick = loadCanonicalPanel;
+$('#canonicalQuery').onkeydown = e => { if(e.key === 'Enter') loadCanonicalPanel(); };
+$('#canonicalOwnerFilter').onkeydown = e => { if(e.key === 'Enter') loadCanonicalPanel(); };
+$('#canonicalCategoryFilter').onkeydown = e => { if(e.key === 'Enter') loadCanonicalPanel(); };
 $('#recallButton').onclick = loadRecallDebug; $('#recallQuery').onkeydown = e => { if(e.key==='Enter') loadRecallDebug(); };
 $('#timelineButton').onclick = loadTimeline; $('#timelineQuery').onkeydown = e => { if(e.key==='Enter') loadTimeline(); }; $('#timelineGroup').onchange = loadTimeline;
 $('#memoryClear').onclick = () => { ['memoryQuery','memorySource','memoryScope','memorySession','memoryVeracity','memoryDegradation','memoryTrustPreset'].forEach(id => $('#'+id).value = ''); $('#memoryKind').value = 'all'; $('#memoryStatus').value = 'active'; $('#memorySort').value = 'recent'; loadMemories(); };

--- a/static/index.html
+++ b/static/index.html
@@ -50,6 +50,7 @@
         <button data-tab="lifecycle"><span>LC</span>Lifecycle</button>
         <button data-tab="graph"><span>KG</span>Knowledge Graph</button>
         <button data-tab="memoria"><span>MR</span>MEMORIA</button>
+        <button data-tab="personafacts" data-title="Persona &amp; Canonical Facts"><span>PF</span>Persona &amp; Facts</button>
         <button data-tab="activity"><span>HS</span>History</button>
         <button data-tab="settings"><span>ST</span>Settings</button>
       </nav>
@@ -459,7 +460,35 @@
             </div>
           </div>
         </section>
+
+        <section id="personafacts" class="tab">
+          <div class="section-head"><h2>Persona &amp; Canonical Facts</h2><span>L3 PERSONA LAYER AND CANONICAL FACTS</span></div>
+          <div class="section-tabs glass" data-section="personafacts">
+            <button data-panel="personaPanel" class="active">Persona</button>
+            <button data-panel="canonicalPanel">Canonical Facts</button>
+          </div>
+          <div id="personaPanel" class="subpanel active">
+            <div class="toolbar glass">
+              <select id="personaTierFilter"><option value="">All tiers</option><option value="permanent">Permanent</option><option value="long_term">Long-term</option><option value="working">Working</option></select>
+              <input id="personaQuery" placeholder="Search persona content or topic…" />
+              <button id="personaSearch" class="primary">Search</button>
+            </div>
+            <div id="personaStats" class="break-row-wrap"></div>
+            <div class="table-wrap"><table><thead><tr><th>Tier</th><th>Topic</th><th>Content</th><th>Reinforced</th><th>Count</th></tr></thead><tbody id="personaRows"></tbody></table></div>
+          </div>
+          <div id="canonicalPanel" class="subpanel">
+            <div class="toolbar glass">
+              <input id="canonicalOwnerFilter" placeholder="Owner…" />
+              <input id="canonicalCategoryFilter" placeholder="Category…" />
+              <input id="canonicalQuery" placeholder="Search owner / category / name / body…" />
+              <button id="canonicalSearch" class="primary">Search</button>
+            </div>
+            <div id="canonicalStats" class="break-row-wrap"></div>
+            <div class="table-wrap"><table><thead><tr><th>Owner</th><th>Category</th><th>Name</th><th>Body</th><th>Version</th></tr></thead><tbody id="canonicalRows"></tbody></table></div>
+          </div>
+        </section>
       </main>
+
       <footer class="app-footer">
         Built by <a href="https://github.com/wysie" target="_blank" rel="noopener noreferrer">wysie</a> with <a href="https://github.com/NousResearch/hermes-agent" target="_blank" rel="noopener noreferrer">Hermes Agent</a> · Thanks to <a href="https://github.com/AxDSan" target="_blank" rel="noopener noreferrer">AxDSan</a> for creating <a href="https://github.com/AxDSan/mnemosyne" target="_blank" rel="noopener noreferrer">Mnemosyne</a>
       </footer>


### PR DESCRIPTION
Adds a unified "Persona & Facts" tab exposing two new Mnemosyne DB features that currently have no UI:

- **L3 Persona facts** from "memoria_persona" (tier filter, topic search, reinforcement count)
- **Canonical facts** from "canonical_facts" (owner/category filters, full-text search, version)

Backend adds two query helpers in DashboardStore and two new API routes:
- GET /api/persona
- GET /api/canonical

Frontend adds a single new sidebar entry "Persona & Facts" with sub-panels for each feature, stat badges, filter toolbars, and proper routing/URL support.

Tested against Mnemosyne v3.10.1.