### PR TITLE
Fix SQLite connection leak (server wedges with EMFILE / "Too many open files")

### DIFF
--- a/dashboard_core.py
+++ b/dashboard_core.py
@@ -8,6 +8,7 @@ import shutil
 import sqlite3
 import uuid
 from collections import Counter
+from contextlib import closing
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -252,7 +253,7 @@ class DashboardStore:
     def _realtime_event_rows(self, limit: int = 25, include_inactive: bool = False) -> list[dict[str, Any]]:
         limit = max(1, min(int(limit or 25), 200))
         events: list[dict[str, Any]] = []
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             for table, memory_kind in (("working_memory", "working"), ("episodic_memory", "episodic")):
                 if table not in tables:
@@ -355,7 +356,7 @@ class DashboardStore:
             stat = path.stat()
             info["size_bytes"] = stat.st_size
             info["modified_at"] = __import__("datetime").datetime.fromtimestamp(stat.st_mtime).isoformat(timespec="seconds")
-            with self.connect() as con:
+            with closing(self.connect()) as con:
                 tables = sorted(self._tables(con))
                 info["tables"] = tables
                 info["table_errors"] = {}
@@ -373,7 +374,7 @@ class DashboardStore:
         return info
 
     def stats(self) -> dict[str, Any]:
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             counts: dict[str, int] = {}
             for table in ["working_memory", "episodic_memory", "memories", "triples", "consolidation_log", "scratchpad"]:
@@ -547,7 +548,7 @@ class DashboardStore:
             wanted.append(("episodic_memory", "episodic"))
 
         rows: list[dict[str, Any]] = []
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             for table, memory_kind in wanted:
                 if table not in tables:
@@ -620,7 +621,7 @@ class DashboardStore:
         return rows[offset:offset + limit]
 
     def get_memory(self, memory_id: str) -> dict[str, Any] | None:
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             for table, memory_kind in [("working_memory", "working"), ("episodic_memory", "episodic")]:
                 if table not in tables:
@@ -776,7 +777,7 @@ class DashboardStore:
                 where.append(f"{col} REGEXP ?")
                 params.append(self._prefix_pattern(value))
         clause = "WHERE " + " AND ".join(where) if where else ""
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             if "triples" not in self._tables(con):
                 return []
             return [dict(r) for r in con.execute(
@@ -829,7 +830,7 @@ class DashboardStore:
             where = "WHERE session_id REGEXP ? OR summary_preview REGEXP ? OR created_at REGEXP ?"
             pattern = self._prefix_pattern(q)
             params = [pattern, pattern, pattern]
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             if "consolidation_log" not in self._tables(con):
                 return []
             return [dict(r) for r in con.execute(
@@ -844,7 +845,7 @@ class DashboardStore:
         memories = self.list_memories(kind="all", session_id=session_id, sort="recent", limit=limit)
         consolidations = self.consolidations(q=session_id, limit=limit)
         triples: list[dict[str, Any]] = []
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             if "triples" in tables:
                 cols = {r[1] for r in con.execute("PRAGMA table_info(triples)")}
@@ -926,7 +927,7 @@ class DashboardStore:
             raise ValueError("memory not found")
         backup_info = self.backup_database() if backup else None
         now = _utc_now()
-        with self.connect_rw() as con:
+        with closing(self.connect_rw()) as con, con:
             updated = 0
             for table in ("working_memory", "episodic_memory"):
                 if table in self._tables(con):
@@ -952,7 +953,7 @@ class DashboardStore:
         if not before:
             raise ValueError("memory not found")
         backup_info = self.backup_database() if backup else None
-        with self.connect_rw() as con:
+        with closing(self.connect_rw()) as con, con:
             updated = 0
             for table in ("working_memory", "episodic_memory", "memories"):
                 if table in self._tables(con):
@@ -976,7 +977,7 @@ class DashboardStore:
         if not before:
             raise ValueError("memory not found")
         backup_info = self.backup_database() if backup else None
-        with self.connect_rw() as con:
+        with closing(self.connect_rw()) as con, con:
             updated = 0
             for table in ("working_memory", "episodic_memory", "memories"):
                 if table in self._tables(con):
@@ -1004,7 +1005,7 @@ class DashboardStore:
             raise ValueError("memory not found")
         backup_info = self.backup_database() if backup else None
         value = valid_until or None
-        with self.connect_rw() as con:
+        with closing(self.connect_rw()) as con, con:
             updated = 0
             for table in ("working_memory", "episodic_memory", "memories"):
                 if table in self._tables(con):
@@ -1035,7 +1036,7 @@ class DashboardStore:
         metadata = dict(before.get("metadata") or {})
         metadata.update({"supersedes": memory_id, "created_by": "mnemosyne-dashboard"})
         backup_info = self.backup_database() if backup else None
-        with self.connect_rw() as con:
+        with closing(self.connect_rw()) as con, con:
             tables = self._tables(con)
             if "working_memory" not in tables:
                 raise ValueError("working_memory table not found")
@@ -1243,7 +1244,7 @@ class DashboardStore:
         limit = max(1, min(int(limit or 80), 300))
         memories_today: list[dict[str, Any]] = []
         recalled_today: list[dict[str, Any]] = []
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             for table, tier in (("working_memory", "working"), ("episodic_memory", "episodic")):
                 if table not in tables:
@@ -1677,7 +1678,7 @@ class DashboardStore:
 
     def memoria_stats(self) -> dict[str, Any]:
         """Overview of all MEMORIA tables."""
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             stats: dict[str, Any] = {"tables": {}}
             for tbl in ["memoria_facts", "memoria_timelines", "memoria_instructions", "memoria_kg", "memoria_preferences"]:
@@ -1703,7 +1704,7 @@ class DashboardStore:
         limit = max(1, min(int(limit or 200), 1000))
         offset = max(0, int(offset or 0))
         q = (q or "").strip()
-        with self.connect() as con:
+        with closing(self.connect()) as con:
             tables = self._tables(con)
             if table not in tables:
                 return []

--- a/tests/test_dashboard_core.py
+++ b/tests/test_dashboard_core.py
@@ -4,6 +4,8 @@ import sys
 import tomllib
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
@@ -1009,3 +1011,31 @@ def test_clear_password_keeps_localhost_admin_mode_allowed(tmp_path, monkeypatch
     assert cfg.auth_enabled is False
     assert cfg.has_password is False
     assert cfg.memory_admin_enabled is True
+
+
+def test_connections_are_closed_after_reads(tmp_path):
+    # Regression: `with self.connect() as con:` manages the transaction but does
+    # NOT close the sqlite3 connection. Every read leaked a db + WAL file handle
+    # until the process hit its fd limit and every request failed with EMFILE
+    # ("Too many open files"). Guard that connections are actually closed.
+    db = tmp_path / 'mnemosyne.db'
+    make_db(db)
+    store = DashboardStore(db)
+
+    opened = []
+    real_connect = store.connect
+
+    def tracking_connect():
+        con = real_connect()
+        opened.append(con)
+        return con
+
+    store.connect = tracking_connect
+
+    store.stats()
+    store.list_memories(kind='all', limit=10)
+
+    assert opened, 'expected the store to open at least one connection'
+    for con in opened:
+        with pytest.raises(sqlite3.ProgrammingError):
+            con.execute('SELECT 1')  # 'Cannot operate on a closed database' when closed


### PR DESCRIPTION
# Fix SQLite connection leak (server wedges with EMFILE / "Too many open files")

## Summary

`DashboardStore` opens a new SQLite connection per operation and uses it as a
context manager:

```python
with self.connect() as con:
    ...
```

In Python's `sqlite3`, using a `Connection` as a context manager **commits or
rolls back the transaction but does not close the connection**. So every request
leaks one connection — and with WAL mode, its `-wal` handle too. Nothing ever
closes them.

Under sustained use the process crosses its file-descriptor limit (macOS default
soft limit is 256) and every subsequent request fails with:

```
[Errno 24] Too many open files
```

The symptom is confusing: the server looks **down** (every endpoint 500s) while
the process is still running and listening — it can no longer open even its own
`config.json` or `static/index.html`. Observed in the wild holding **124 open
handles to `mnemosyne.db` and 123 to `mnemosyne.db-wal`** before wedging.

## Fix

Wrap all 16 call sites in `contextlib.closing()` so the connection is closed on
block exit. Read-only sites (`connect()`) simply close. Read-write sites
(`connect_rw()`) keep the connection's own context manager for commit/rollback,
chained after `closing()` so both run in the right order (transaction first,
then close):

```python
# read-only
with closing(self.connect()) as con:
    ...

# read-write — commit/rollback preserved, then close
with closing(self.connect_rw()) as con, con:
    ...
```

No API or behavior change. The read-only URI (`mode=ro`), the `0.0.0.0` default
bind, admin-gating, and every other safety invariant in `CONTRIBUTING.md` are
untouched.

## Regression test

`tests/test_dashboard_core.py::test_connections_are_closed_after_reads` tracks
every connection the store opens during `stats()` + `list_memories()` and asserts
each one is closed afterwards (a closed `sqlite3.Connection` raises
`ProgrammingError` on use). It **fails on the current code** (`DID NOT RAISE
ProgrammingError`) and passes with this fix.

Verified manually as well: after the fix, 120 requests hold the process's open
`mnemosyne.db` handle count flat at 0 between requests (was climbing ~2 per
request).

## Checklist

- [x] Ruff passes (`ruff check .` — all checks passed)
- [x] Pytest passes (46 tests, including the new regression test)
- [x] Python compile check passes (`compileall`)
- [x] `node --check static/app.js` passes
- [x] README/config docs — no user-facing change
- [x] Security notes — network/auth/read-only model unchanged

## How this was found

A running instance had been serving fine for ~9 days, then started returning
`500 [Errno 24] Too many open files` on every endpoint. `lsof` on the pid showed
the 124/123 db+WAL handle pile-up; the connection-per-request-without-close
pattern in `dashboard_core.py` was the cause.
